### PR TITLE
fix: tag_centering 노드 추가 및 센터링 로직 수정

### DIFF
--- a/src/tag_hotspot_nav/launch/perception.launch.py
+++ b/src/tag_hotspot_nav/launch/perception.launch.py
@@ -100,4 +100,20 @@ def generate_launch_description():
             parameters=[{'tag_size': tag_size, 'map_frame': map_frame}],
             remappings=tf_remaps,
         ),
+        # 4) tag_centering — YOLO 후보 감지 시 탐사 일시정지 + 태그 정렬
+        Node(
+            package='tag_hotspot_nav',
+            executable='tag_centering',
+            name='tag_centering',
+            output='screen',
+            parameters=[{
+                'cmd_vel_topic': '/j100_0915/cmd_vel',
+                'trigger_conf': 0.5,
+                'center_tol': 0.12,
+                'angular_speed': 0.4,
+                'dwell_time': 2.0,
+                'cooldown': 10.0,
+            }],
+            remappings=tf_remaps,
+        ),
     ])

--- a/src/tag_hotspot_nav/tag_hotspot_nav/tag_centering.py
+++ b/src/tag_hotspot_nav/tag_hotspot_nav/tag_centering.py
@@ -40,7 +40,7 @@ class TagCenteringNode(Node):
         self.declare_parameter('max_center_time', 4.0)    # [s] 정렬 타임아웃
         self.declare_parameter('dwell_time', 2.0)         # [s] 정렬 후 관측 정지
         self.declare_parameter('cooldown', 10.0)          # [s] 재트리거 방지
-        self.declare_parameter('candidate_timeout', 0.7)  # [s] 후보 끊기면 태그 놓침
+        self.declare_parameter('candidate_timeout', 1.5)  # [s] 후보 끊기면 태그 놓침
         self.declare_parameter('only_front', True)        # front 카메라 후보만 정렬
         self.declare_parameter('base_frame', 'base_link')
         self.declare_parameter('map_frame', 'map')
@@ -62,7 +62,7 @@ class TagCenteringNode(Node):
         self.match_tol = float(self.get_parameter('match_tol').value)
 
         self.state = IDLE
-        self._explore_active = False     # 외부 go/resume 시 True (탐사 중일 때만 동작)
+        self._explore_active = True     # 외부 go/resume 시 True (탐사 중일 때만 동작)
         self._bearing = 0.0
         self._cand_t = None              # 마지막 후보 수신 시각
         self._t0 = 0.0                   # 상태 진입 시각
@@ -174,7 +174,7 @@ class TagCenteringNode(Node):
                 self.state = DWELL; self._t0 = now
             else:
                 # bearing>0(좌)이면 +회전(좌), bearing<0(우)이면 -회전
-                self._pub_cmd(0.0, math.copysign(self.ang_spd, self._bearing))
+                self._pub_cmd(0.0, math.copysign(self.ang_spd * min(1.0, abs(self._bearing) / 0.3), self._bearing))
 
         elif self.state == DWELL:
             self._pub_cmd(0.0, 0.0)              # 정지 유지 → 관측 누적


### PR DESCRIPTION
문제: perception.launch.py에 tag_centering 노드가 없어서 탐사 중 AprilTag 발견해도 아무 반응 없었음

수정 내용:
- perception.launch.py에 tag_centering 노드 추가
- _explore_active 초기값 False → True 수정 (go 명령 못 받아도 태그 감지 즉시 반응하도록)
- candidate_timeout 0.7s → 1.5s 연장 (주행 중 진동으로 YOLO 신호 잠깐 끊겨도 포기 안 하도록)
- 센터링 회전속도 고정 → 비례 감속으로 변경 (태그 가까워질수록 속도 줄여서 진동 방지)